### PR TITLE
Add conversation export/import feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Interactive Control**: Configure turn limits, approve tool calls, and guide the process
 - **Comprehensive Logging**: Track all interactions and tool calls for debugging and analysis
 - **Safety Features**: Built-in approval mechanisms for potentially dangerous operations
+- **Conversation Export/Import**: Save and reload conversation history
 
 ## 📦 Installation
 
@@ -124,6 +125,8 @@ llm loop "Set up a git repository and make initial commit" \
 | `--internal-cl` | Chain limit for tool calls within a single turn |
 | `--no-log` | Disable logging to database |
 | `--log` | Force logging even if globally disabled |
+| `--export-conversation` | Save conversation history to JSON |
+| `--import-conversation` | Load conversation history from JSON before start |
 
 ## 📚 Examples
 

--- a/llm_loop/cli.py
+++ b/llm_loop/cli.py
@@ -135,6 +135,18 @@ def register_commands(cli):
             "continue (0 for no limit)."
         ),
     )
+    @click.option(
+        "export_path",
+        "--export-conversation",
+        type=click.Path(dir_okay=False, allow_dash=False, resolve_path=True),
+        help="Export conversation history to this JSON file",
+    )
+    @click.option(
+        "import_path",
+        "--import-conversation",
+        type=click.Path(dir_okay=False, allow_dash=False, resolve_path=True),
+        help="Load conversation history from this JSON file",
+    )
     def loop_command(
         prompt_text: str,
         model_id: Optional[str],
@@ -150,6 +162,8 @@ def register_commands(cli):
         no_log_flag: bool,
         force_log_flag: bool,
         max_turns: int,
+        export_path: Optional[str],
+        import_path: Optional[str],
     ):
         """
         Run LLM in a loop to achieve a goal, automatically calling tools.
@@ -253,6 +267,13 @@ def register_commands(cli):
         # Execute the loop
         try:
             conversation_manager = ConversationManager(model, loop_config)
+            if import_path:
+                click.echo(
+                    conversation_manager.import_conversation(
+                        pathlib.Path(import_path)
+                    ),
+                    err=True,
+                )
             result: LoopResult = conversation_manager.execute_loop(
                 prompt_text,
                 final_system_prompt,
@@ -260,6 +281,13 @@ def register_commands(cli):
                 actual_options,
                 key,
             )
+            if export_path:
+                click.echo(
+                    conversation_manager.export_conversation(
+                        pathlib.Path(export_path)
+                    ),
+                    err=True,
+                )
 
             click.echo("\n--- Loop finished ---", err=True)
 


### PR DESCRIPTION
## Summary
- allow saving and loading conversation history
- add `--export-conversation` and `--import-conversation` options
- document new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f640a8e48320ae4363d9b5ba8ad0